### PR TITLE
fix: fvmの設定ファイルを追加

### DIFF
--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,0 +1,4 @@
+{
+  "flutterSdkVersion": "2.10.4",
+  "flavors": {}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 #.vscode/
 .vscode/settings.json
 
+# FVM related
+.fvm/flutter_sdk
+
 # Flutter/Dart/Pub related
 # Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
 /pubspec.lock

--- a/.vscode/base_fvm_settings.json
+++ b/.vscode/base_fvm_settings.json
@@ -1,0 +1,3 @@
+{
+  "dart.flutterSdkPaths": [".fvm/flutter_sdk"]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,5 +55,6 @@
         "--debug"
       ]
     }
-  ]
+  ],
+  "dart.flutterSdkPaths": [".fvm/flutter_sdk"]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,6 +55,5 @@
         "--debug"
       ]
     }
-  ],
-  "dart.flutterSdkPaths": [".fvm/flutter_sdk"]
+  ]
 }

--- a/documents/README.md
+++ b/documents/README.md
@@ -147,7 +147,7 @@ asdf で Flutter の SDK バージョンを管理する方法は、この記事�
 
 を参考にしてください。asdf でなくても、fvm や（混乱しなければ）マシンのグローバルで使用する Flutter SDK でも構いません。
 
-また、皆さんの .vscode などのエディタの設定が異なることを考慮して、`.vscode/settings.json` は gitignore することにしています。代わりに、`.vscode/base_settings.json` で asdf を使用している人用の設定のサンプルはおいているので、
+また、皆さんの .vscode などのエディタの設定が異なることを考慮して、`.vscode/settings.json` は gitignore することにしています。代わりに、`.vscode/base_settings.json` で asdf を使用している人用の設定のサンプル、 `base_fvm_settings` でfvmを使用している人用の設定のサンプルはおいているので、
 
 ```shell
 cd ~/workspace


### PR DESCRIPTION
- https://zenn.dev/riscait/articles/melos-for-multiple-packages-dart-projects
- https://zenn.dev/riscait/articles/flutter-version-management

こちら参考にfvmの設定ファイル追加、 `.fvm/flutter_sdk` をignoreしました。
`stable` にするとどうもうまくいかなかった(過去に入れたstableが使われてしまった）ため明示的にバージョン入れています。