### PR TITLE
fix: android12系で立ち上がらないためtargetSdkVersion、minSdkVersionなどを変更

### DIFF
--- a/packages/sample/example/android/app/build.gradle
+++ b/packages/sample/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -44,8 +44,9 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
-        minSdkVersion 16
-        targetSdkVersion 30
+        minSdkVersion 19
+        targetSdkVersion 31
+        multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/sample/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/sample/example/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:exported="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues


### PR DESCRIPTION
android12系のEmulator（おそらく実機も）で立ち上がらないため `sample/example` 内のファイルを12対応に書き換えました。(sampleをコピペして作るため）
他のpackageディレクトリは変更していません。

- packages/sample/example/android/app/build.gradle
- packages/sample/example/android/app/src/main/AndroidManifest.xml